### PR TITLE
EW-706: Upgrade keycloak to latest version 23.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Keycloak base image with ErWIn-IDM extensions
-FROM quay.io/keycloak/keycloak:21.1.2 AS base
+FROM quay.io/keycloak/keycloak:23.0.6 AS base
 
 # ErWIn specific extensions (providers, themes, etc.)
 #COPY src/conf/ /opt/keycloak/conf/


### PR DESCRIPTION
# Description
Updates the base image to keycloak version 23.0.6

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/EW-706
- https://github.com/hpi-schul-cloud/dof_app_deploy/pull/787
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/4752

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
